### PR TITLE
[OPDEV-5872] Require logger before activesupport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .byebug_history
 .config
+.idea
 .yardoc
 _yardoc
 coverage

--- a/jets.gemspec
+++ b/jets.gemspec
@@ -51,7 +51,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "hashie"
   spec.add_dependency "jets-html-sanitizer"
   spec.add_dependency "kramdown"
-  spec.add_dependency "logger"
   spec.add_dependency "memoist"
   spec.add_dependency "mini_mime"
   spec.add_dependency "rack"

--- a/jets.gemspec
+++ b/jets.gemspec
@@ -51,6 +51,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "hashie"
   spec.add_dependency "jets-html-sanitizer"
   spec.add_dependency "kramdown"
+  spec.add_dependency "logger"
   spec.add_dependency "memoist"
   spec.add_dependency "mini_mime"
   spec.add_dependency "rack"

--- a/lib/jets.rb
+++ b/lib/jets.rb
@@ -2,6 +2,7 @@ $stdout.sync = true unless ENV["JETS_STDOUT_SYNC"] == "0"
 
 $:.unshift(File.expand_path("../", __FILE__))
 
+require "logger"
 require "jets/core_ext/bundler"
 require "jets/core_ext/file"
 require "jets/autoloaders"


### PR DESCRIPTION
This is a 🐞 bug fix.

[OPDEV-5872] Require logger before activesupport

## Summary

Without this change we have an error on jets build:

```
bundler: failed to load command: jets (/opt/gems/ruby/3.2.0/bin/jets)
/opt/gems/ruby/3.2.0/gems/activesupport-6.1.7.10/lib/active_support/logger_thread_safe_level.rb:16:in `<module:LoggerThreadSafeLevel>': uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger (NameError)

    Logger::Severity.constants.each do |severity|
          ^^^^^^^^^^
```



[OPDEV-5872]: https://onepark.atlassian.net/browse/OPDEV-5872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ